### PR TITLE
Save & Search uk.gov's CSV of Licensed Sponsors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
     "description": "Select a word and match with CSV data",
     "permissions": [
         "activeTab",
-        "storage"
+        "storage",
+        "https://assets.publishing.service.gov.uk/*"
     ],
     "browser_action": {
         "default_popup": "popup/popup.html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mantine/core": "^7.5.2",
         "@mantine/hooks": "^7.5.2",
         "@tabler/icons-react": "^2.47.0",
+        "classnames": "^2.5.1",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -740,6 +741,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clsx": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@mantine/core": "^7.5.2",
         "@mantine/hooks": "^7.5.2",
         "@tabler/icons-react": "^2.47.0",
+        "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@types/chrome": "^0.0.260",
+        "@types/papaparse": "^5.3.14",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
         "esbuild": "^0.20.0",
@@ -574,6 +576,24 @@
       "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.14.tgz",
+      "integrity": "sha512-LxJ4iEFcpqc6METwp9f6BV6VVc43m6MfH0VqFosHvrUgfXiFe6ww7R3itkOQ+TCK6Y+Iv/+RnnvtRZnkc5Kc9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
@@ -1120,6 +1140,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -1793,6 +1818,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@mantine/core": "^7.5.2",
         "@mantine/hooks": "^7.5.2",
+        "@tabler/icons-react": "^2.47.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -515,6 +516,31 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@tabler/icons": {
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.47.0.tgz",
+      "integrity": "sha512-4w5evLh+7FUUiA1GucvGj2ReX2TvOjEr4ejXdwL/bsjoSkof6r1gQmzqI+VHrE2CpJpB3al7bCTulOkFa/RcyA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.47.0.tgz",
+      "integrity": "sha512-iqly2FvCF/qUbgmvS8E40rVeYY7laltc5GUjRxQj59DuX0x/6CpKHTXt86YlI2whg4czvd/c8Ce8YR08uEku0g==",
+      "dependencies": {
+        "@tabler/icons": "2.47.0",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@types/chrome": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mantine/core": "^7.5.2",
     "@mantine/hooks": "^7.5.2",
+    "@tabler/icons-react": "^2.47.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/chrome": "^0.0.260",
+    "@types/papaparse": "^5.3.14",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "esbuild": "^0.20.0",
@@ -24,6 +25,7 @@
     "@mantine/core": "^7.5.2",
     "@mantine/hooks": "^7.5.2",
     "@tabler/icons-react": "^2.47.0",
+    "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@mantine/core": "^7.5.2",
     "@mantine/hooks": "^7.5.2",
     "@tabler/icons-react": "^2.47.0",
+    "classnames": "^2.5.1",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/content.ts
+++ b/src/content.ts
@@ -33,7 +33,7 @@ document.addEventListener('mouseup', async function (event) {
     }
 });
 
-function createPopup(x, y, selectedText) {
+function createPopup(x: number, y: number, selectedText: string) {
     // Create a new popup div
     const popupDiv = document.createElement('div');
     popupDiv.style.position = 'absolute';

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,10 +1,41 @@
+import { Card, Switch, Text, Tabs, rem } from '@mantine/core';
+import { IconSettings } from '@tabler/icons-react';
+
 import React from "react";
-import { Card, Switch, Text } from '@mantine/core';
 import { isExtensionEnabled, setIsExtensionEnabled } from "../storage/localStorage"
 
-export const SettingsPage: React.FC<{}> = () => {
+const TABS = {
+    search: "search",
+    settings: "settings",
+} as const;
+
+export const PopupPage: React.FC<{}> = () => {
+  const iconStyle = { width: rem(12), height: rem(12) };
+  const [activeTab, setActiveTab] = React.useState<string>(TABS.search);
+  return (
+    <Card withBorder shadow="sm" radius="md" className="main-page">
+
+      <Tabs color="indigo" value={activeTab} onChange={val => val != null && setActiveTab(val)}>
+        <Tabs.List>
+          <Tabs.Tab value={TABS.search}>Search</Tabs.Tab>
+          <Tabs.Tab value={TABS.settings} leftSection={<IconSettings style={iconStyle}/>}>Settings</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value={TABS.search}>
+          Gallery tab content
+        </Tabs.Panel>
+
+        <Tabs.Panel value={TABS.settings}>
+          <SettingsPage />
+        </Tabs.Panel>
+      </Tabs>
+    </Card>
+  );
+}
+
+const SettingsPage: React.FC<{}> = () => {
     return (
-        <Card withBorder shadow="sm" radius="md" className="main-card">
+        <Card withBorder shadow="sm" radius="md">
             <Card.Section withBorder inheritPadding py="xs">
                 <Text fw={500}>Settings</Text>
             </Card.Section>

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,13 +1,11 @@
-import { Switch, Text, Tabs, rem, Input, Button } from '@mantine/core';
-import { useToggle } from '@mantine/hooks';
-
-import { IconSettings } from '@tabler/icons-react';
-import Papa from 'papaparse';
+import { Switch, Text, Tabs, Notification, rem, Input, Button, Loader, Card, TableData, Table, FocusTrap } from "@mantine/core";
+import { IconSettings } from "@tabler/icons-react";
 
 import React from "react";
-import { isExtensionEnabled, setIsExtensionEnabled } from "../storage/localStorage"
-import { useBoolean } from '../utils';
-
+import { getCompanyData, setCompanyData, isExtensionEnabled, setIsExtensionEnabled } from "../storage/localStorage"
+import { useBoolean } from "../utils";
+import { fetchCsv, metchCsv } from "./downloadCsv";
+import classnames from "classnames";
 
 const TABS = {
     search: "search",
@@ -15,136 +13,190 @@ const TABS = {
 } as const;
 
 export const PopupPage: React.FC<{}> = () => {
-  const iconStyle = { width: rem(12), height: rem(12) };
-  const [activeTab, setActiveTab] = React.useState<string>(TABS.search);
-  return (
-      <Tabs className="main-page" value={activeTab} onChange={val => val != null && setActiveTab(val)} color="indigo">
+    const iconStyle = { width: rem(12), height: rem(12) };
+    const [activeTab, setActiveTab] = React.useState<string>(TABS.search);
+    return (
+        <Tabs className="main-page" value={activeTab} onChange={val => val != null && setActiveTab(val)} color="indigo">
 
-        <Tabs.List>
-          <Tabs.Tab value={TABS.search}>Search</Tabs.Tab>
-          <Tabs.Tab value={TABS.settings} leftSection={<IconSettings style={iconStyle}/>}>Settings</Tabs.Tab>
-        </Tabs.List>
+            <Tabs.List>
+                <Tabs.Tab value={TABS.search}>Search</Tabs.Tab>
+                <Tabs.Tab value={TABS.settings} leftSection={<IconSettings style={iconStyle} />}>Settings</Tabs.Tab>
+            </Tabs.List>
 
-        <Tabs.Panel value={TABS.search} className="tab-panel">
-          <SearchPage />
-        </Tabs.Panel>
+            <Tabs.Panel value={TABS.search} className={classnames("tab-panel", "search-panel")}>
+                <SearchPage />
+            </Tabs.Panel>
 
-        <Tabs.Panel value={TABS.settings} className="tab-panel">
-          <SettingsPage />
-        </Tabs.Panel>
+            <Tabs.Panel value={TABS.settings} className={"tab-panel"}>
+                <SettingsPage />
+            </Tabs.Panel>
 
-      </Tabs>
-  );
+        </Tabs>
+    );
 }
 
 const SettingsPage: React.FC<{}> = () => {
-  return (
-      <>
-          <Text mt="sm" c="dimmed" size="sm">
-              We can populate this nicely with{' '}
-              <Text span inherit c="var(--mantine-color-anchor)">
-                  links to stuff
-              </Text>{' '}
-              and some settings. Right now we only have one.
-          </Text>
-          <EnabledSwitch />
-      </>
-  );
+    return (
+        <>
+            <Text c="dimmed" size="sm">
+                We can populate this nicely with{" "}
+                <Text span inherit c="var(--mantine-color-anchor)">
+                    links to stuff
+                </Text>{" "}
+                and some settings. Right now we only have one.
+            </Text>
+            <EnabledSwitch />
+        </>
+    );
 }
 
 function EnabledSwitch() {
-  const [checked, setChecked] = React.useState(false);
-
-  const fetchIsEnabled = React.useCallback(async () => {
-      const isEnabled = await isExtensionEnabled();
-      setChecked(isEnabled ?? false);
-  }, []);
-
-  React.useEffect(() => { fetchIsEnabled(); }, [fetchIsEnabled]);
-
-  const toggleEnabled = React.useCallback(async () => {
-      await setIsExtensionEnabled(!checked);
-      fetchIsEnabled();
-  }, [checked, fetchIsEnabled]);
-
-  return (
-      <Switch
-          checked={checked}
-          onChange={toggleEnabled}
-          label={"Enabled"}
-      />
-  );
-}
-
-const DownloadCSVPanel: React.FC<{}> = () => {
-  const [url, setUrl] = React.useState("");
-  const [rows, setRows] = React.useState<string[]>([]);
-  const {setTrue: setLoading, setFalse: setLoaded, value: isLoading} = useBoolean();
-
-  const handleDownloadClicked = React.useCallback(async () => {
-    setLoading();
-    console.log('url', url);
-    try {
-      const res = await fetch(url, {
-          mode: "cors"
-      });
-      const body = await res.text();
-      const rawLines = body.split("\n").slice(0, 20).join('\n');
-      
-      Papa.parse<string>(rawLines, {
-        header: true,
-        complete: response => {
-          const results = response.data;
-          setRows(results.map(res => JSON.stringify(res)));
-          setLoaded();
+    const [checked, setChecked] = React.useState(false);
+    const fetchIsEnabled = React.useCallback(async () => {
+        try {
+            const isEnabled = await isExtensionEnabled();
+            setChecked(isEnabled ?? false);
+        } catch (e) {
+            console.error("Could not read `isEnabled`", e);
         }
-      });
-    }
-    catch (e) {
-      console.log('fuck', e);
-      setLoaded();
-    }
-    
-  }, [url]);
+    }, []);
 
-  return (
-    <>
-      {/* Maybe be more helpful here? Render a hyperlink to Uk.gov's page? Through which the users can grab the csv url? */}
-      <Text mt="sm" c="dimmed" size="sm">
-          The list of authorized sponsors is not present in the local storage.
-          Please enter the URL for this list in the space provided below.
-      </Text>
+    React.useEffect(() => { fetchIsEnabled(); }, [fetchIsEnabled]);
 
-      <Text mt="sm" c="dimmed" size="sm">          
-          Storing this list in local storage will enhance the extension's
-          performance and reduce unnecessary data usage.
-      </Text>
+    const toggleEnabled = React.useCallback(async () => {
+        await setIsExtensionEnabled(!checked);
+        fetchIsEnabled();
+    }, [checked, fetchIsEnabled]);
 
-      {/* https://assets.publishing.service.gov.uk/media/65cb4f16a7ded0000c79e4f3/2024-02-13_-_Worker_and_Temporary_Worker.csv */}
-      {/*
-        We can auto detect this url by reading uk-gov's page.
-        In later iterations, below input field should be a fallback
-        for cases where the plugin can't figure out this url automatically.
-      */}
-      <Input
-        placeholder="Download URL for the csv"
-        value={url}
-        onChange={e => setUrl(e.target.value)}
-        mt="md"
-      />
-      <div className="reverse-flex">
-        <Button loading={isLoading} size="xs" variant="filled" onClick={handleDownloadClicked}>Save CSV</Button>
-      </div>
-      {rows.map((row, index) => <Text key={index}>{row}</Text>)}
-    </>
-  );
+    return (
+        <Switch
+            checked={checked}
+            onChange={toggleEnabled}
+            label={"Enabled"}
+        />
+    );
 }
 
 const SearchPage: React.FC<{}> = () => {
-  // insert logic here to branch off if CSV is found in local storage.
-  // 1. load from store & show spinner
-  // 2. reroute accordingly
-  // 3. potentially handle errors -> we also don't know what _can_ go wrong
-  //  - we can prolly just flush everything clean, and reload. Storage is an essential cache
-  return <DownloadCSVPanel />
+    const [companyNames, setcompanyNames] = React.useState<"loading" | "error" | string[]>("loading");
+    const fetchCompanies = React.useCallback(async () => {
+        try {
+            const companyData = await getCompanyData();
+            setcompanyNames(companyData.companies);
+        } catch (e) {
+            console.error("Could not read `company data`", e);
+            // setcompanyNames([]);
+            setcompanyNames("error");
+        }
+    }, []);
+
+    React.useEffect(() => { fetchCompanies(); }, [fetchCompanies]);
+
+    if (companyNames == "loading") {
+        return <Loader />
+    }
+
+    // TODO: maybe expose means to handle errors here
+    if (companyNames == "error") {
+        return (
+            <div className="padded">
+                <Notification withCloseButton={false} color="red" title="Error">
+                    Failed to read data from chrome's local storage.
+                </Notification>
+            </div>
+        );
+    }
+
+    return companyNames.length > 0 ? (<CompaniesPanel companyNames={companyNames} />) : (<DownloadCSVPanel setcompanyNames={setcompanyNames} />);
 };
+
+const CompaniesPanel: React.FC<{ companyNames: string[] }> = ({ companyNames }) => {
+    const [searchText, setSearchText] = React.useState("");
+    const filteredCompanyNames = React.useMemo(() => {
+        console.log('searchText', searchText);
+        console.log('companyNames.lengths', companyNames.length);
+        const lowerCaseText = searchText.toLowerCase();
+        if (searchText === "") {
+            return companyNames;
+        }
+        return companyNames.filter(name => name.toLowerCase().includes(lowerCaseText));
+    }, [companyNames, searchText]);
+
+    const tableData: TableData = React.useMemo(() => ({
+        body: filteredCompanyNames.slice(0, 50).map(name => [<Text key={name}>{name}</Text>]),
+    }), [filteredCompanyNames]);
+
+    return (
+        <>
+            <div className="padded">
+                <Text fw={500}>Licensed Companies</Text>
+                <FocusTrap active>
+                    <Input
+                        placeholder="Search company names"
+                        value={searchText}
+                        onChange={e => setSearchText(e.target.value)}
+                        mt="md"
+                    />
+                </FocusTrap>
+                {/* TODO: Pluralize this correctly */}
+                {/* TODO: Format the number nicely */}
+                <Text c="dimmed" size="sm"><b>{filteredCompanyNames.length}</b> companies matching your filter</Text>
+            </div>
+            <Table.ScrollContainer minWidth={200}>
+                <Table highlightOnHover data={tableData} />
+            </Table.ScrollContainer>
+        </>
+    );
+}
+
+const DownloadCSVPanel: React.FC<{setcompanyNames: (companyNames: string[]) => void}> = ( { setcompanyNames }) => {
+    const [url, setUrl] = React.useState("");
+    const { setTrue: setLoading, setFalse: setLoaded, value: isLoading } = useBoolean();
+
+    const handleDownloadClicked = React.useCallback(async () => {
+        setLoading();
+        try {
+            const companyNames = await fetchCsv(url);
+            // const companies = await metchCsv(MOCK_ROWS.join("\n"));
+            await setCompanyData({ companies: companyNames });
+            setLoaded();
+            setcompanyNames(companyNames);
+            console.log("companyNames", companyNames);
+        }
+        catch (e) {
+            console.log("fuck", e);
+            setLoaded();
+        }
+    }, [url]);
+
+    return (
+        <>
+            {/* TODO: Maybe be more helpful here? Render a hyperlink to Uk.gov"s page? Through which the users can grab the csv url? */}
+            <Text mt="sm" c="dimmed" size="sm">
+                The list of authorized sponsors is not present in the local storage.
+                Please enter the URL for this list in the space provided below.
+            </Text>
+
+            <Text mt="sm" c="dimmed" size="sm">
+                Storing this list in local storage will enhance the extension"s
+                performance and reduce unnecessary data usage.
+            </Text>
+
+            {/* https://assets.publishing.service.gov.uk/media/65cb4f16a7ded0000c79e4f3/2024-02-13_-_Worker_and_Temporary_Worker.csv */}
+            {/* TODO:
+                We can auto detect this url by reading uk-gov"s page.
+                In later iterations, below input field should be a fallback
+                for cases where the plugin can"t figure out this url automatically.
+            */}
+            <Input
+                placeholder="Download URL for the csv"
+                value={url}
+                onChange={e => setUrl(e.target.value)}
+                mt="md"
+            />
+            <div className="reverse-flex">
+                <Button loading={isLoading} size="xs" variant="filled" onClick={handleDownloadClicked}>Save CSV</Button>
+            </div>
+        </>
+    );
+}

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,8 +1,13 @@
-import { Card, Switch, Text, Tabs, rem } from '@mantine/core';
+import { Switch, Text, Tabs, rem, Input, Button } from '@mantine/core';
+import { useToggle } from '@mantine/hooks';
+
 import { IconSettings } from '@tabler/icons-react';
+import Papa from 'papaparse';
 
 import React from "react";
 import { isExtensionEnabled, setIsExtensionEnabled } from "../storage/localStorage"
+import { useBoolean } from '../utils';
+
 
 const TABS = {
     search: "search",
@@ -13,67 +18,133 @@ export const PopupPage: React.FC<{}> = () => {
   const iconStyle = { width: rem(12), height: rem(12) };
   const [activeTab, setActiveTab] = React.useState<string>(TABS.search);
   return (
-    <Card withBorder shadow="sm" radius="md" className="main-page">
+      <Tabs className="main-page" value={activeTab} onChange={val => val != null && setActiveTab(val)} color="indigo">
 
-      <Tabs color="indigo" value={activeTab} onChange={val => val != null && setActiveTab(val)}>
         <Tabs.List>
           <Tabs.Tab value={TABS.search}>Search</Tabs.Tab>
           <Tabs.Tab value={TABS.settings} leftSection={<IconSettings style={iconStyle}/>}>Settings</Tabs.Tab>
         </Tabs.List>
 
-        <Tabs.Panel value={TABS.search}>
-          Gallery tab content
+        <Tabs.Panel value={TABS.search} className="tab-panel">
+          <SearchPage />
         </Tabs.Panel>
 
-        <Tabs.Panel value={TABS.settings}>
+        <Tabs.Panel value={TABS.settings} className="tab-panel">
           <SettingsPage />
         </Tabs.Panel>
+
       </Tabs>
-    </Card>
   );
 }
 
 const SettingsPage: React.FC<{}> = () => {
-    return (
-        <Card withBorder shadow="sm" radius="md">
-            <Card.Section withBorder inheritPadding py="xs">
-                <Text fw={500}>Settings</Text>
-            </Card.Section>
-
-            <Text mt="sm" c="dimmed" size="sm">
-                We can populate this nicely with{' '}
-                <Text span inherit c="var(--mantine-color-anchor)">
-                    links to stuff
-                </Text>{' '}
-                and some settings. Right now we only have one.
-            </Text>
-            <EnabledSwitch />
-        </Card>
-    );
+  return (
+      <>
+          <Text mt="sm" c="dimmed" size="sm">
+              We can populate this nicely with{' '}
+              <Text span inherit c="var(--mantine-color-anchor)">
+                  links to stuff
+              </Text>{' '}
+              and some settings. Right now we only have one.
+          </Text>
+          <EnabledSwitch />
+      </>
+  );
 }
-
-
 
 function EnabledSwitch() {
-    const [checked, setChecked] = React.useState(false);
+  const [checked, setChecked] = React.useState(false);
 
-    const fetchIsEnabled = React.useCallback(async () => {
-        const isEnabled = await isExtensionEnabled();
-        setChecked(isEnabled ?? false);
-    }, []);
+  const fetchIsEnabled = React.useCallback(async () => {
+      const isEnabled = await isExtensionEnabled();
+      setChecked(isEnabled ?? false);
+  }, []);
 
-    React.useEffect(() => { fetchIsEnabled(); }, [fetchIsEnabled]);
+  React.useEffect(() => { fetchIsEnabled(); }, [fetchIsEnabled]);
 
-    const toggleEnabled = React.useCallback(async () => {
-        await setIsExtensionEnabled(!checked);
-        fetchIsEnabled();
-    }, [checked, fetchIsEnabled]);
+  const toggleEnabled = React.useCallback(async () => {
+      await setIsExtensionEnabled(!checked);
+      fetchIsEnabled();
+  }, [checked, fetchIsEnabled]);
 
-    return (
-        <Switch
-            checked={checked}
-            onChange={toggleEnabled}
-            label={"Enabled"}
-        />
-    );
+  return (
+      <Switch
+          checked={checked}
+          onChange={toggleEnabled}
+          label={"Enabled"}
+      />
+  );
 }
+
+const DownloadCSVPanel: React.FC<{}> = () => {
+  const [url, setUrl] = React.useState("");
+  const [rows, setRows] = React.useState<string[]>([]);
+  const {setTrue: setLoading, setFalse: setLoaded, value: isLoading} = useBoolean();
+
+  const handleDownloadClicked = React.useCallback(async () => {
+    setLoading();
+    console.log('url', url);
+    try {
+      const res = await fetch(url, {
+          mode: "cors"
+      });
+      const body = await res.text();
+      const rawLines = body.split("\n").slice(0, 20).join('\n');
+      
+      Papa.parse<string>(rawLines, {
+        header: true,
+        complete: response => {
+          const results = response.data;
+          setRows(results.map(res => JSON.stringify(res)));
+          setLoaded();
+        }
+      });
+    }
+    catch (e) {
+      console.log('fuck', e);
+      setLoaded();
+    }
+    
+  }, [url]);
+
+  return (
+    <>
+      {/* Maybe be more helpful here? Render a hyperlink to Uk.gov's page? Through which the users can grab the csv url? */}
+      <Text mt="sm" c="dimmed" size="sm">
+          The list of authorized sponsors is not present in the local storage.
+          Please enter the URL for this list in the space provided below.
+      </Text>
+
+      <Text mt="sm" c="dimmed" size="sm">          
+          Storing this list in local storage will enhance the extension's
+          performance and reduce unnecessary data usage.
+      </Text>
+
+      {/* https://assets.publishing.service.gov.uk/media/65cb4f16a7ded0000c79e4f3/2024-02-13_-_Worker_and_Temporary_Worker.csv */}
+      {/*
+        We can auto detect this url by reading uk-gov's page.
+        In later iterations, below input field should be a fallback
+        for cases where the plugin can't figure out this url automatically.
+      */}
+      <Input
+        placeholder="Download URL for the csv"
+        value={url}
+        onChange={e => setUrl(e.target.value)}
+        mt="md"
+      />
+      <div className="reverse-flex">
+        <Button loading={isLoading} size="xs" variant="filled" onClick={handleDownloadClicked}>Save CSV</Button>
+      </div>
+      {rows.map((row, index) => <Text key={index}>{row}</Text>)}
+    </>
+  );
+}
+
+const SearchPage: React.FC<{}> = () => {
+  // insert logic here to branch off if CSV is found in local storage.
+  // 1. load from store & show spinner
+  // 2. reroute accordingly
+  // 3. potentially handle errors -> we also don't know what _can_ go wrong
+  //  - we can prolly just flush everything clean, and reload. Storage is an essential cache
+  return <DownloadCSVPanel />
+};

--- a/src/popup/app.tsx
+++ b/src/popup/app.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { MantineProvider } from '@mantine/core';
-import { SettingsPage } from "./SettingsPage";
+import { PopupPage } from "./Popup";
 
 import '@mantine/core/styles.css';
 
@@ -11,7 +11,7 @@ if (rawRootDiv != null) {
     const root = createRoot(rawRootDiv);
     root.render(
         <MantineProvider>
-            <SettingsPage />
+            <PopupPage />
         </MantineProvider>
     );
 } else {

--- a/src/popup/downloadCsv.ts
+++ b/src/popup/downloadCsv.ts
@@ -1,0 +1,40 @@
+import Papa from 'papaparse';
+
+type GovUKRow = [string, string, string, string, string];
+const RELEVANT_ROUTE = "skilled worker";
+
+// We should not blindly trust the GovUKRow type here, as there is no run time type check.
+// gov.uk can technically return anything and Papa parse might be swalllowing certain errors.
+const transformParsedCsv = (govUkRows: GovUKRow[]): string[] => (
+    govUkRows
+        .filter(row => row.length === 5 && row[4].toLowerCase() === RELEVANT_ROUTE)
+        .map(row => row[0])
+);
+
+export const fetchCsv = async (url: string) => {
+    console.log('fetching url:', url);
+    const res = await fetch(url, {
+        mode: "cors"
+    });
+    const body = await res.text();
+    const parsed = await papaParse(body);
+    return transformParsedCsv(parsed.data);
+};
+
+export const metchCsv = async (body: string) => {
+    const govUkRows = (await papaParse(body)).data;
+    return transformParsedCsv(govUkRows);
+};
+
+export const papaParse = (csvString: string): Promise<Papa.ParseResult<GovUKRow>> => {
+    return new Promise((resolve, reject) => {
+        try {
+            Papa.parse<GovUKRow>(csvString, {
+                header: false,
+                complete: response => resolve(response)
+            });
+        } catch (e) {
+            reject(e);
+        }
+    });
+}

--- a/src/popup/style.scss
+++ b/src/popup/style.scss
@@ -1,8 +1,15 @@
 * { margin: 0px; }
 
+.reverse-flex {
+    display: flex;
+    flex-direction: row-reverse;
+}
+
+.padded { padding: 10px; }
+
 .main-page {
     height: 400px;
-    overflow-y: auto;
+    overflow-y: hidden;
     width: 400px;
     padding: 10px 0px;
 }
@@ -10,11 +17,17 @@
 .tab-panel {
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
+    height: 100%;
     padding: 10px;
     gap: 5px;
 }
 
-.reverse-flex {
+.search-panel {
+    padding: 0px;
+}
+
+.companies-card-header {
     display: flex;
-    flex-direction: row-reverse;
+    justify-content: space-between;
 }

--- a/src/popup/style.scss
+++ b/src/popup/style.scss
@@ -1,3 +1,6 @@
 * { margin: 0px; }
 
-.main-card { width: 400px; }
+.main-page {
+    width: 400px;
+    padding: 10px 0px;
+}

--- a/src/popup/style.scss
+++ b/src/popup/style.scss
@@ -1,6 +1,20 @@
 * { margin: 0px; }
 
 .main-page {
+    height: 400px;
+    overflow-y: auto;
     width: 400px;
     padding: 10px 0px;
+}
+
+.tab-panel {
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    gap: 5px;
+}
+
+.reverse-flex {
+    display: flex;
+    flex-direction: row-reverse;
 }

--- a/src/storage/localStorage.ts
+++ b/src/storage/localStorage.ts
@@ -1,6 +1,12 @@
 type StorageObject = { [name: string]: any };
 
+// Creating this as a dict, as we might want to save some metadata under the same key.
+export type CompanyData = {
+    companies: string[];
+}
+
 const IS_ENABLED = "isExtensionEnabled";
+const COMPANY_DATA = "companyData";
 
 export const isExtensionEnabled = async (): Promise<boolean> => {
     const isEnabled = await getFromLocalStorage(IS_ENABLED) as boolean | undefined;
@@ -9,6 +15,15 @@ export const isExtensionEnabled = async (): Promise<boolean> => {
 
 export const setIsExtensionEnabled = async (isEnabled: boolean): Promise<void> => {
     return saveToLocalStorage({[IS_ENABLED]: isEnabled});
+}
+
+export const getCompanyData = async (): Promise<CompanyData> => {
+    const companyData = await getFromLocalStorage(COMPANY_DATA) as CompanyData | undefined;
+    return companyData ?? { companies: [] };
+}
+
+export const setCompanyData = async (companyData: CompanyData): Promise<void> => {
+    return saveToLocalStorage({[COMPANY_DATA]: companyData});
 }
 
 const getFromLocalStorage = async function (key: string): Promise<any> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,17 @@
+import React from 'react'
+
+interface UseBoolean {
+  value: boolean
+  setValue: (value: boolean) => void;
+  setTrue: () => void
+  setFalse: () => void
+  toggle: () => void
+}
+
+export function useBoolean(defaultValue?: boolean): UseBoolean {
+  const [value, setValue] = React.useState(defaultValue ?? false);
+  const toggle = React.useCallback(() => setValue(x => !x), []);
+  const setTrue = React.useCallback(() => setValue(true), []);
+  const setFalse = React.useCallback(() => setValue(false), []);
+  return { value, setValue, setTrue, setFalse, toggle }
+}


### PR DESCRIPTION
https://github.com/irmk323/sponsor-checker/assets/32279273/6ec4afa1-5458-44a7-8953-a5c727b30f8c

## Summary of Changes:
- Adds functionality to pull uk.gov's `Register of Worker and Temporary Worker licensed sponsors` CSV file. The way that this works:
  - When the popup page is ...popped up (pun intended), the plugin now checks the local storage and prompts the user to provide a url for a valid `sponsors-csv`, if the local storage contains no company data.
  - This file is pulled, then its rows are filtered for `Skilled Worker`, and remaining company names are saved to chrome's local storage. 
- Implements search functionality for licensed companies in the popup page.

The overall UX here needs some FLUPs.

## Flups:
- Type these as the code is reviewed